### PR TITLE
Pull changes from development into essex-hack [1/16]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -62,6 +62,7 @@ locale_additions:
         noconfig: No Configuration Options
       openstack:
         index:
+          title: OpenStack
           barclamp: Project
           state: Status
           proposal: Proposal

--- a/crowbar_framework/app/controllers/openstack_controller.rb
+++ b/crowbar_framework/app/controllers/openstack_controller.rb
@@ -14,6 +14,11 @@
 # 
 
 class OpenstackController < BarclampController
-    
+   
+  def index
+    @title = I18n.t('title', :scope=>'barclamp.openstack.index')
+    super
+  end
+   
 end
 


### PR DESCRIPTION
Synchronize essex-hack with development. Among other things, this
pulls in:
- Numerous UI improvements.
- Enhancements and bugfixes galore in the dev tool and build system.
- Sledgehammer on CentOS 6.2 support.
- Somewhat more standardized patch management for our Chef and Rails
  patches.

This pull request series has been smoketested on virtual machines, and
is able to spin up vms in Nova using the dashboard.

 crowbar.yml                                        |    8 +++-----
 .../app/controllers/openstack_controller.rb        |    7 ++++++-
 2 files changed, 9 insertions(+), 6 deletions(-)
