### PR TITLE
Add os_support stanzas to selected barclamps. [11/12]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -30,7 +30,6 @@ barclamp:
   requires:
     - @crowbar
   os_support:
-    - ubuntu-10.10
     - ubuntu-12.04
 
 crowbar:


### PR DESCRIPTION
This pull request adds os_support stanzas to various barclamps to
allow the dev tool to infer the proper OS for a given build.

 crowbar.yml |    1 -
 1 file changed, 1 deletion(-)

Crowbar-Pull-ID: 18a9548803fe8236bd2918dcca092fdf4ffa73be

Crowbar-Release: development
