### PR TITLE
fix issues with parsing crowbar.yml files on Ruby 1.9 [2/3]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -28,7 +28,7 @@ barclamp:
   member:
     - openstack
   requires:
-    - @crowbar
+    - '@crowbar'
   os_support:
     - ubuntu-12.04
 


### PR DESCRIPTION
Some of the crowbar.yml files had illegal YAML syntax.  This bundle
fixes that, and also facilitates easier debugging of similar problems
in the future.

 crowbar.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 9d9e0e065e56866b3d17ffa42bb595796a133c2a

Crowbar-Release: development
