### PR TITLE
Fix Ruby 1.9 related syntax issues in the crowbar.yml files. [3/5]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -30,7 +30,7 @@ barclamp:
   member:
     - openstack
   requires:
-    - @crowbar
+    - '@crowbar'
     - nova_dashboard
     - keystone
   os_support:


### PR DESCRIPTION
Ruby 1.9 barfs on some of the syntax in our crowbar.yml files due to
having a stricter notion of what is valid YML.

 crowbar.yml |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: ffc3762d231760e1644ae1583d71b1790716c46f

Crowbar-Release: feature/grizzly
