### PR TITLE
temporarily set secret key_path to /var/chef/data_bags/openstack_data_bag_secret until we've worked out how to create on admin node and push to /etc/chef/ which is default location. [1/1]

### DIFF
--- a/chef/cookbooks/openstack-common/attributes/default.rb
+++ b/chef/cookbooks/openstack-common/attributes/default.rb
@@ -40,7 +40,7 @@ default["openstack"]["auth"]["validate_certs"] = true
 # routine that looks up the value of encrypted databag values. This routine
 # uses the secret key file located at the following location to decrypt the
 # values in the data bag.
-default["openstack"]["secret"]["key_path"] = "/etc/chef/openstack_data_bag_secret"
+default["openstack"]["secret"]["key_path"] = "/var/chef/data_bags/openstack_data_bag_secret"
 
 # The name of the encrypted data bag that stores service user passwords, with
 # each key in the data bag corresponding to a named OpenStack service, like


### PR DESCRIPTION
 .../openstack-common/attributes/default.rb         |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 5246c77c5096967a2536dd0dfc9fb64b958af287

Crowbar-Release: development
