### PR TITLE
Set databag secret path to /var/chef/data_bags instead of /etc/chef [1/1]

### DIFF
--- a/chef/cookbooks/openstack-common/attributes/default.rb
+++ b/chef/cookbooks/openstack-common/attributes/default.rb
@@ -41,7 +41,7 @@ default['openstack']['auth']['validate_certs'] = true
 # routine that looks up the value of encrypted databag values. This routine
 # uses the secret key file located at the following location to decrypt the
 # values in the data bag.
-default['openstack']['secret']['key_path'] = '/etc/chef/openstack_data_bag_secret'
+default['openstack']['secret']['key_path'] = '/var/chef/data_bags/openstack_data_bag_secret'
 
 # The name of the encrypted data bag that stores service user passwords, with
 # each key in the data bag corresponding to a named OpenStack service, like


### PR DESCRIPTION
 chef/cookbooks/openstack-common/README.md          |   10 +-
 .../openstack-common/attributes/default.rb         |  246 ++++++++++----------
 .../openstack-common/libraries/database.rb         |    4 +-
 .../openstack-common/libraries/endpoints.rb        |    2 +-
 .../openstack-common/libraries/passwords.rb        |   30 +--
 chef/cookbooks/openstack-common/recipes/default.rb |   74 +++---
 chef/cookbooks/openstack-common/recipes/logging.rb |   15 +-
 .../recipes/set_endpoints_by_interface.rb          |    1 +
 chef/cookbooks/openstack-common/recipes/sysctl.rb  |   19 +-
 .../openstack-common/spec/password_spec.rb         |   18 +-
 10 files changed, 204 insertions(+), 215 deletions(-)

Crowbar-Pull-ID: 03a6c3962cc13f69f1d4a5bb094c9bccb4661b8a

Crowbar-Release: development
