### PR TITLE
Added ability to specify IP address [1/1]

### DIFF
--- a/chef/cookbooks/openstack-common/libraries/network.rb
+++ b/chef/cookbooks/openstack-common/libraries/network.rb
@@ -31,4 +31,17 @@ module ::Openstack
       end
     end
   end
+
+
+  # return the IPv4 (default) address of the service.
+  #
+  # @param [Mash] the service to query.
+  # @return [String] The IPv4 address.
+  def address_for_service service
+    if service['bind_address']
+      service['bind_address']
+    else
+      address_for service['bind_interface']
+    end
+  end
 end


### PR DESCRIPTION
This adds a method that checks to see if 'bind_address' is set on a service,
and if so it uses that address, otherwise address_for is called.

 .../openstack-common/libraries/network.rb          |   13 +++++++++++++
 1 file changed, 13 insertions(+)

Crowbar-Pull-ID: 88686cbab23956b8d02c9dc282d28541ec72e87b

Crowbar-Release: development
