### PR TITLE
Fix IP to service assignment [3/3]

### DIFF
--- a/chef/cookbooks/openstack-common/attributes/database.rb
+++ b/chef/cookbooks/openstack-common/attributes/database.rb
@@ -70,39 +70,44 @@
 # across many zones.
 #
 
+# ******************** Database Endpoint **************************************
+default['openstack']['endpoints']['db']['host'] = '127.0.0.1'
+default['openstack']['endpoints']['db']['scheme'] = nil
+default['openstack']['endpoints']['db']['port'] = '3306'
+default['openstack']['endpoints']['db']['path'] = nil
+default['openstack']['endpoints']['db']['bind_interface'] = nil
+
 # Default database attributes
 default['openstack']['db']['server_role'] = 'os-ops-database'
 default['openstack']['db']['service_type'] = 'mysql'
-default['openstack']['db']['host'] = '127.0.0.1'
-default['openstack']['db']['port'] = '3306'
 
 # Database used by the OpenStack Compute (Nova) service
 default['openstack']['db']['compute']['service_type'] = node['openstack']['db']['service_type']
-default['openstack']['db']['compute']['host'] = node['openstack']['db']['host']
-default['openstack']['db']['compute']['port'] = node['openstack']['db']['port']
+default['openstack']['db']['compute']['host'] = node['openstack']['endpoints']['db']['host']
+default['openstack']['db']['compute']['port'] = node['openstack']['endpoints']['db']['port']
 default['openstack']['db']['compute']['db_name'] = 'nova'
 default['openstack']['db']['compute']['username'] = 'nova'
 
 # Database used by the OpenStack Identity (Keystone) service
 default['openstack']['db']['identity']['service_type'] = node['openstack']['db']['service_type']
-default['openstack']['db']['identity']['host'] = node['openstack']['db']['host']
-default['openstack']['db']['identity']['port'] = node['openstack']['db']['port']
+default['openstack']['db']['identity']['host'] = node['openstack']['endpoints']['db']['host']
+default['openstack']['db']['identity']['port'] = node['openstack']['endpoints']['db']['port']
 default['openstack']['db']['identity']['db_name'] = 'keystone'
 default['openstack']['db']['identity']['username'] = 'keystone'
 default['openstack']['db']['identity']['migrate'] = true
 
 # Database used by the OpenStack Image (Glance) service
 default['openstack']['db']['image']['service_type'] = node['openstack']['db']['service_type']
-default['openstack']['db']['image']['host'] = node['openstack']['db']['host']
-default['openstack']['db']['image']['port'] = node['openstack']['db']['port']
+default['openstack']['db']['image']['host'] = node['openstack']['endpoints']['db']['host']
+default['openstack']['db']['image']['port'] = node['openstack']['endpoints']['db']['port']
 default['openstack']['db']['image']['db_name'] = 'glance'
 default['openstack']['db']['image']['username'] = 'glance'
 default['openstack']['db']['image']['migrate'] = true
 
 # Database used by the OpenStack Network (Neutron) service
 default['openstack']['db']['network']['service_type'] = node['openstack']['db']['service_type']
-default['openstack']['db']['network']['host'] = node['openstack']['db']['host']
-default['openstack']['db']['network']['port'] = node['openstack']['db']['port']
+default['openstack']['db']['network']['host'] = node['openstack']['endpoints']['db']['host']
+default['openstack']['db']['network']['port'] = node['openstack']['endpoints']['db']['port']
 default['openstack']['db']['network']['db_name'] = 'neutron'
 default['openstack']['db']['network']['username'] = 'neutron'
 # Enable the use of eventlet's db_pool for MySQL. The flags sql_min_pool_size,
@@ -122,29 +127,29 @@ default['openstack']['db']['network']['sql_idle_timeout'] = 3600
 
 # Database used by the OpenStack Block Storage (Cinder) service
 default['openstack']['db']['block-storage']['service_type'] = node['openstack']['db']['service_type']
-default['openstack']['db']['block-storage']['host'] = node['openstack']['db']['host']
-default['openstack']['db']['block-storage']['port'] = node['openstack']['db']['port']
+default['openstack']['db']['block-storage']['host'] = node['openstack']['endpoints']['db']['host']
+default['openstack']['db']['block-storage']['port'] = node['openstack']['endpoints']['db']['port']
 default['openstack']['db']['block-storage']['db_name'] = 'cinder'
 default['openstack']['db']['block-storage']['username'] = 'cinder'
 
 # Database used by the OpenStack Dashboard (Horizon)
 default['openstack']['db']['dashboard']['service_type'] = node['openstack']['db']['service_type']
-default['openstack']['db']['dashboard']['host'] = node['openstack']['db']['host']
-default['openstack']['db']['dashboard']['port'] = node['openstack']['db']['port']
+default['openstack']['db']['dashboard']['host'] = node['openstack']['endpoints']['db']['host']
+default['openstack']['db']['dashboard']['port'] = node['openstack']['endpoints']['db']['port']
 default['openstack']['db']['dashboard']['db_name'] = 'horizon'
 default['openstack']['db']['dashboard']['username'] = 'dash'
 
 # Database used by OpenStack Metering (Ceilometer)
 default['openstack']['db']['metering']['service_type'] = node['openstack']['db']['service_type']
-default['openstack']['db']['metering']['host'] = node['openstack']['db']['host']
-default['openstack']['db']['metering']['port'] = node['openstack']['db']['port']
+default['openstack']['db']['metering']['host'] = node['openstack']['endpoints']['db']['host']
+default['openstack']['db']['metering']['port'] = node['openstack']['endpoints']['db']['port']
 default['openstack']['db']['metering']['db_name'] = 'ceilometer'
 default['openstack']['db']['metering']['username'] = 'ceilometer'
 
 # Database used by OpenStack Orchestration (Heat)
 default['openstack']['db']['orchestration']['service_type'] = node['openstack']['db']['service_type']
-default['openstack']['db']['orchestration']['host'] = node['openstack']['db']['host']
-default['openstack']['db']['orchestration']['port'] = node['openstack']['db']['port']
+default['openstack']['db']['orchestration']['host'] = node['openstack']['endpoints']['db']['host']
+default['openstack']['db']['orchestration']['port'] = node['openstack']['endpoints']['db']['port']
 default['openstack']['db']['orchestration']['db_name'] = 'heat'
 default['openstack']['db']['orchestration']['username'] = 'heat'
 

--- a/chef/cookbooks/openstack-common/attributes/messaging.rb
+++ b/chef/cookbooks/openstack-common/attributes/messaging.rb
@@ -23,11 +23,16 @@
 # expected to create the user, pass, vhost in a wrapper rabbitmq cookbook.
 #
 
+# ******************** RabbitMQ Endpoint **************************************
+default['openstack']['endpoints']['mq']['host'] = '127.0.0.1'
+default['openstack']['endpoints']['mq']['scheme'] = nil
+default['openstack']['endpoints']['mq']['port'] = '5672'
+default['openstack']['endpoints']['mq']['path'] = nil
+default['openstack']['endpoints']['mq']['bind_interface'] = nil
+
 # Default messaging attributes
 default['openstack']['mq']['server_role'] = 'os-ops-messaging'
 default['openstack']['mq']['service_type'] = 'rabbitmq'
-default['openstack']['mq']['host'] = '127.0.0.1'
-default['openstack']['mq']['port'] = '5672'
 default['openstack']['mq']['user'] = 'guest'
 default['openstack']['mq']['vhost'] = '/'
 
@@ -36,8 +41,8 @@ default['openstack']['mq']['block-storage']['service_type'] = node['openstack'][
 default['openstack']['mq']['block-storage']['notification_topic'] = 'notifications'
 case node['openstack']['mq']['block-storage']['service_type']
 when 'qpid'
-  default['openstack']['mq']['block-storage']['qpid']['host'] = node['openstack']['mq']['host']
-  default['openstack']['mq']['block-storage']['qpid']['port'] = node['openstack']['mq']['port']
+  default['openstack']['mq']['block-storage']['qpid']['host'] = node['openstack']['endpoints']['mq']['host']
+  default['openstack']['mq']['block-storage']['qpid']['port'] = node['openstack']['endpoints']['mq']['port']
   default['openstack']['mq']['block-storage']['qpid']['qpid_hosts'] = ['127.0.0.1:5672']
   default['openstack']['mq']['block-storage']['qpid']['username'] = ''
   default['openstack']['mq']['block-storage']['qpid']['password'] = ''
@@ -55,8 +60,8 @@ when 'qpid'
 when 'rabbitmq'
   default['openstack']['mq']['block-storage']['rabbit']['userid'] = node['openstack']['mq']['user']
   default['openstack']['mq']['block-storage']['rabbit']['vhost'] = node['openstack']['mq']['vhost']
-  default['openstack']['mq']['block-storage']['rabbit']['port'] = node['openstack']['mq']['port']
-  default['openstack']['mq']['block-storage']['rabbit']['host'] = node['openstack']['mq']['host']
+  default['openstack']['mq']['block-storage']['rabbit']['port'] = node['openstack']['endpoints']['mq']['port']
+  default['openstack']['mq']['block-storage']['rabbit']['host'] = node['openstack']['endpoints']['mq']['host']
   default['openstack']['mq']['block-storage']['rabbit']['ha'] = false
   default['openstack']['mq']['block-storage']['rabbit']['use_ssl'] = false
   default['openstack']['mq']['block-storage']['rabbit']['notification_topic'] = node['openstack']['mq']['block-storage']['notification_topic']
@@ -66,8 +71,8 @@ end
 default['openstack']['mq']['compute']['service_type'] = node['openstack']['mq']['service_type']
 case node['openstack']['mq']['compute']['service_type']
 when 'qpid'
-  default['openstack']['mq']['compute']['qpid']['host'] = node['openstack']['mq']['host']
-  default['openstack']['mq']['compute']['qpid']['port'] = node['openstack']['mq']['port']
+  default['openstack']['mq']['compute']['qpid']['host'] = node['openstack']['endpoints']['mq']['host']
+  default['openstack']['mq']['compute']['qpid']['port'] = node['openstack']['endpoints']['mq']['port']
   default['openstack']['mq']['compute']['qpid']['qpid_hosts'] = ['127.0.0.1:5672']
   default['openstack']['mq']['compute']['qpid']['username'] = ''
   default['openstack']['mq']['compute']['qpid']['password'] = ''
@@ -83,8 +88,8 @@ when 'qpid'
 when 'rabbitmq'
   default['openstack']['mq']['compute']['rabbit']['userid'] = node['openstack']['mq']['user']
   default['openstack']['mq']['compute']['rabbit']['vhost'] = node['openstack']['mq']['vhost']
-  default['openstack']['mq']['compute']['rabbit']['port'] = node['openstack']['mq']['port']
-  default['openstack']['mq']['compute']['rabbit']['host'] = node['openstack']['mq']['host']
+  default['openstack']['mq']['compute']['rabbit']['port'] = node['openstack']['endpoints']['mq']['port']
+  default['openstack']['mq']['compute']['rabbit']['host'] = node['openstack']['endpoints']['mq']['host']
   default['openstack']['mq']['compute']['rabbit']['ha'] = false
   default['openstack']['mq']['compute']['rabbit']['use_ssl'] = false
 end
@@ -95,8 +100,8 @@ default['openstack']['mq']['image']['notifier_strategy'] = 'noop'
 default['openstack']['mq']['image']['notification_topic'] = 'glance_notifications'
 case node['openstack']['mq']['image']['service_type']
 when 'qpid'
-  default['openstack']['mq']['image']['qpid']['host'] = node['openstack']['mq']['host']
-  default['openstack']['mq']['image']['qpid']['port'] = node['openstack']['mq']['port']
+  default['openstack']['mq']['image']['qpid']['host'] = node['openstack']['endpoints']['mq']['host']
+  default['openstack']['mq']['image']['qpid']['port'] = node['openstack']['endpoints']['mq']['port']
   default['openstack']['mq']['image']['qpid']['qpid_hosts'] = ['127.0.0.1:5672']
   default['openstack']['mq']['image']['qpid']['username'] = ''
   default['openstack']['mq']['image']['qpid']['password'] = ''
@@ -114,8 +119,8 @@ when 'qpid'
 when 'rabbitmq'
   default['openstack']['mq']['image']['rabbit']['userid'] = node['openstack']['mq']['user']
   default['openstack']['mq']['image']['rabbit']['vhost'] = node['openstack']['mq']['vhost']
-  default['openstack']['mq']['image']['rabbit']['port'] = node['openstack']['mq']['port']
-  default['openstack']['mq']['image']['rabbit']['host'] = node['openstack']['mq']['host']
+  default['openstack']['mq']['image']['rabbit']['port'] = node['openstack']['endpoints']['mq']['port']
+  default['openstack']['mq']['image']['rabbit']['host'] = node['openstack']['endpoints']['mq']['host']
   default['openstack']['mq']['image']['rabbit']['use_ssl'] = false
   default['openstack']['mq']['image']['rabbit']['notification_topic'] = node['openstack']['mq']['image']['notification_topic']
 end
@@ -124,8 +129,8 @@ end
 default['openstack']['mq']['metering']['service_type'] = node['openstack']['mq']['service_type']
 case node['openstack']['mq']['metering']['service_type']
 when 'qpid'
-  default['openstack']['mq']['metering']['qpid']['host'] = node['openstack']['mq']['host']
-  default['openstack']['mq']['metering']['qpid']['port'] = node['openstack']['mq']['port']
+  default['openstack']['mq']['metering']['qpid']['host'] = node['openstack']['endpoints']['mq']['host']
+  default['openstack']['mq']['metering']['qpid']['port'] = node['openstack']['endpoints']['mq']['port']
   default['openstack']['mq']['metering']['qpid']['qpid_hosts'] = ['127.0.0.1:5672']
   default['openstack']['mq']['metering']['qpid']['username'] = ''
   default['openstack']['mq']['metering']['qpid']['password'] = ''
@@ -142,8 +147,8 @@ when 'qpid'
 when 'rabbitmq'
   default['openstack']['mq']['metering']['rabbit']['userid'] = node['openstack']['mq']['user']
   default['openstack']['mq']['metering']['rabbit']['vhost'] = node['openstack']['mq']['vhost']
-  default['openstack']['mq']['metering']['rabbit']['port'] = node['openstack']['mq']['port']
-  default['openstack']['mq']['metering']['rabbit']['host'] = node['openstack']['mq']['host']
+  default['openstack']['mq']['metering']['rabbit']['port'] = node['openstack']['endpoints']['mq']['port']
+  default['openstack']['mq']['metering']['rabbit']['host'] = node['openstack']['endpoints']['mq']['host']
   default['openstack']['mq']['metering']['rabbit']['ha'] = false
   default['openstack']['mq']['metering']['rabbit']['use_ssl'] = false
 end
@@ -152,8 +157,8 @@ end
 default['openstack']['mq']['network']['service_type'] = node['openstack']['mq']['service_type']
 case node['openstack']['mq']['network']['service_type']
 when 'qpid'
-  default['openstack']['mq']['network']['qpid']['host'] = node['openstack']['mq']['host']
-  default['openstack']['mq']['network']['qpid']['port'] = node['openstack']['mq']['port']
+  default['openstack']['mq']['network']['qpid']['host'] = node['openstack']['endpoints']['mq']['host']
+  default['openstack']['mq']['network']['qpid']['port'] = node['openstack']['endpoints']['mq']['port']
   default['openstack']['mq']['network']['qpid']['qpid_hosts'] = ['127.0.0.1:5672']
   default['openstack']['mq']['network']['qpid']['username'] = ''
   default['openstack']['mq']['network']['qpid']['password'] = ''
@@ -170,8 +175,8 @@ when 'qpid'
 when 'rabbitmq'
   default['openstack']['mq']['network']['rabbit']['userid'] = node['openstack']['mq']['user']
   default['openstack']['mq']['network']['rabbit']['vhost'] = node['openstack']['mq']['vhost']
-  default['openstack']['mq']['network']['rabbit']['port'] = node['openstack']['mq']['port']
-  default['openstack']['mq']['network']['rabbit']['host'] = node['openstack']['mq']['host']
+  default['openstack']['mq']['network']['rabbit']['port'] = node['openstack']['endpoints']['mq']['port']
+  default['openstack']['mq']['network']['rabbit']['host'] = node['openstack']['endpoints']['mq']['host']
   default['openstack']['mq']['network']['rabbit']['ha'] = false
 end
 
@@ -179,8 +184,8 @@ end
 default['openstack']['mq']['orchestration']['service_type'] = node['openstack']['mq']['service_type']
 case node['openstack']['mq']['orchestration']['service_type']
 when 'qpid'
-  default['openstack']['mq']['orchestration']['qpid']['host'] = node['openstack']['mq']['host']
-  default['openstack']['mq']['orchestration']['qpid']['port'] = node['openstack']['mq']['port']
+  default['openstack']['mq']['orchestration']['qpid']['host'] = node['openstack']['endpoints']['mq']['host']
+  default['openstack']['mq']['orchestration']['qpid']['port'] = node['openstack']['endpoints']['mq']['port']
   default['openstack']['mq']['orchestration']['qpid']['qpid_hosts'] = ['127.0.0.1:5672']
   default['openstack']['mq']['orchestration']['qpid']['username'] = ''
   default['openstack']['mq']['orchestration']['qpid']['password'] = ''
@@ -197,8 +202,8 @@ when 'qpid'
 when 'rabbitmq'
   default['openstack']['mq']['orchestration']['rabbit']['userid'] = node['openstack']['mq']['user']
   default['openstack']['mq']['orchestration']['rabbit']['vhost'] = node['openstack']['mq']['vhost']
-  default['openstack']['mq']['orchestration']['rabbit']['port'] = node['openstack']['mq']['port']
-  default['openstack']['mq']['orchestration']['rabbit']['host'] = node['openstack']['mq']['host']
+  default['openstack']['mq']['orchestration']['rabbit']['port'] = node['openstack']['endpoints']['mq']['port']
+  default['openstack']['mq']['orchestration']['rabbit']['host'] = node['openstack']['endpoints']['mq']['host']
   default['openstack']['mq']['orchestration']['rabbit']['ha'] = false
   default['openstack']['mq']['orchestration']['rabbit']['use_ssl'] = false
 end

--- a/chef/cookbooks/openstack-common/libraries/endpoints.rb
+++ b/chef/cookbooks/openstack-common/libraries/endpoints.rb
@@ -84,6 +84,20 @@ module ::Openstack # rubocop:disable Documentation
     end
   end
 
+  # Return the IPv4 address for the hash.
+  #
+  # If the bind_interface is set, then return the first IP on the interface.
+  # otherwise return the IP specified in the host attribute.
+  def address(hash)
+    bind_interface = hash['bind_interface'] if hash['bind_interface']
+
+    if bind_interface
+      return address_for bind_interface
+    else
+      return hash['host']
+    end
+  end
+
   private
 
   # Instead of specifying the verbose node['openstack']['endpoints'][name],

--- a/chef/cookbooks/openstack-common/libraries/search.rb
+++ b/chef/cookbooks/openstack-common/libraries/search.rb
@@ -70,7 +70,7 @@ module ::Openstack # rubocop:disable Documentation
   def rabbit_servers # rubocop:disable MethodLength
     if node['openstack']['mq']['servers']
       servers = node['openstack']['mq']['servers']
-      port = node['openstack']['mq']['port']
+      port = node['openstack']['endpoints']['mq']['port']
 
       servers.map { |s| "#{s}:#{port}" }.join ','
     else
@@ -80,7 +80,7 @@ module ::Openstack # rubocop:disable Documentation
         # in the wrapper cookbook.  See the reference cookbook
         # openstack-ops-messaging.
         address = n['openstack']['mq']['listen']
-        port = n['openstack']['mq']['port']
+        port = n['openstack']['endpoints']['mq']['port']
 
         "#{address}:#{port}"
       end.sort.join ','

--- a/chef/cookbooks/openstack-common/libraries/uri.rb
+++ b/chef/cookbooks/openstack-common/libraries/uri.rb
@@ -36,7 +36,7 @@ module ::Openstack # rubocop:disable Documentation
       return nil unless hash['host']
 
       scheme = hash['scheme'] ? hash['scheme'] : 'http'
-      host = hash['host']
+      host = address hash
       port = hash['port']  # Returns nil if missing, which is fine.
       path = hash['path']  # Returns nil if missing, which is fine.
       ::URI::Generic.new scheme, nil, host, port, nil, path, nil, nil, nil

--- a/chef/cookbooks/openstack-common/recipes/set_endpoints_by_interface.rb
+++ b/chef/cookbooks/openstack-common/recipes/set_endpoints_by_interface.rb
@@ -25,7 +25,7 @@ end
 # iterate over the endpoints, look for bind_interface to set the host
 node['openstack']['endpoints'].keys.each do |component|
   unless node['openstack']['endpoints'][component]['bind_interface'].nil?
-    ip_address = address_for node['openstack']['endpoints'][component]['bind_interface']
+    ip_address = address node['openstack']['endpoints'][component]
     node.default['openstack']['endpoints'][component]['host'] = ip_address
   end
 end

--- a/chef/cookbooks/openstack-common/spec/endpoints_spec.rb
+++ b/chef/cookbooks/openstack-common/spec/endpoints_spec.rb
@@ -161,4 +161,23 @@ describe ::Openstack do
       @subject.db_uri('compute', 'user', 'pass').should == expect
     end
   end
+
+  describe '#address' do
+    it 'returns interface IP if bind_interface specified' do
+      ep_hash = {
+        'bind_interface' => 'eth0',
+        'host' => '5.6.7.8'
+      }
+      @subject.stub('address_for').and_return '1.2.3.4'
+      @subject.address(ep_hash).should == '1.2.3.4'
+    end
+    it 'returns host IP if bind_interface not specified' do
+      ep_hash = {
+        'bind_interface' => nil,
+        'host' => '5.6.7.8'
+      }
+      @subject.stub('address_for').and_return '1.2.3.4'
+      @subject.address(ep_hash).should == '5.6.7.8'
+    end
+  end
 end

--- a/chef/cookbooks/openstack-common/spec/search_spec.rb
+++ b/chef/cookbooks/openstack-common/spec/search_spec.rb
@@ -7,7 +7,9 @@ describe ::Openstack do
   before do
     @chef_run = ::ChefSpec::Runner.new(::CHEFSPEC_OPTS) do |n|
       n.set['openstack']['mq'] = {
-        'server_role' => 'openstack-ops-mq',
+        'server_role' => 'openstack-ops-mq'
+      }
+      n.set['openstack']['endpoints']['mq'] = {
         'port' => 5672
       }
     end
@@ -105,8 +107,8 @@ describe ::Openstack do
   describe '#rabbit_servers' do
     it 'returns rabbit servers' do
       nodes = [
-        { 'openstack' => { 'mq' => { 'listen' => '1.1.1.1', 'port' => '5672' } } },
-        { 'openstack' => { 'mq' => { 'listen' => '2.2.2.2', 'port' => '5672' } } }
+        { 'openstack' => { 'mq' => { 'listen' => '1.1.1.1' }, 'endpoints' => { 'mq' => { 'port' => '5672' } } } },
+        { 'openstack' => { 'mq' => { 'listen' => '2.2.2.2' }, 'endpoints' => { 'mq' => { 'port' => '5672' } } } }
       ]
       @subject.stub(:node).and_return @chef_run.node
       @subject.stub(:search_for)
@@ -118,9 +120,9 @@ describe ::Openstack do
 
     it 'returns sorted rabbit servers' do
       nodes = [
-        { 'openstack' => { 'mq' => { 'listen' => '3.3.3.3', 'port' => '5672'  } } },
-        { 'openstack' => { 'mq' => { 'listen' => '1.1.1.1', 'port' => '5672' } } },
-        { 'openstack' => { 'mq' => { 'listen' => '2.2.2.2', 'port' => '5672'  } } }
+        { 'openstack' => { 'mq' => { 'listen' => '3.3.3.3' }, 'endpoints' => { 'mq' => { 'port' => '5672'  } } } },
+        { 'openstack' => { 'mq' => { 'listen' => '1.1.1.1' }, 'endpoints' => { 'mq' => { 'port' => '5672' } } } },
+        { 'openstack' => { 'mq' => { 'listen' => '2.2.2.2' }, 'endpoints' => { 'mq' => { 'port' => '5672' } } } }
       ]
       @subject.stub(:node).and_return @chef_run.node
       @subject.stub(:search_for)


### PR DESCRIPTION
This set of pull requests contains the following:
1. Adds the ability to specify an IP address that a service should bind to.
   This is done by eliminating the calls to address_for in the messaging
   and database upstream cookbooks and replacing them with endpoints.
   We will need to convert calls to address_for to endpoints as we go
   through the upstream cookbooks.
2. Modifications to the database and messaging barclamp custom recipes
   so that the IP address assigned by crowbar networking is pulled out
   and given to the service to use.
   
   .../openstack-common/attributes/database.rb        |   41 +++++++-------
   .../openstack-common/attributes/messaging.rb       |   57 +++++++++++---------
   .../openstack-common/libraries/endpoints.rb        |   14 +++++
   .../cookbooks/openstack-common/libraries/search.rb |    4 +-
   chef/cookbooks/openstack-common/libraries/uri.rb   |    2 +-
   .../recipes/set_endpoints_by_interface.rb          |    2 +-
   .../openstack-common/spec/endpoints_spec.rb        |   19 +++++++
   .../cookbooks/openstack-common/spec/search_spec.rb |   14 ++---
   8 files changed, 99 insertions(+), 54 deletions(-)

Crowbar-Pull-ID: b47bd52b0a9f7a155862bb2bb596e3fbd880aa1e

Crowbar-Release: development
