### PR TITLE
Bind the keystone address to 0.0.0.0 [3/3]

### DIFF
--- a/chef/cookbooks/openstack-common/attributes/default.rb
+++ b/chef/cookbooks/openstack-common/attributes/default.rb
@@ -118,6 +118,13 @@ default['openstack']['yum']['repo-key'] = 'https://raw.github.com/redhat-opensta
 
 # ******************** OpenStack Identity Endpoints ***************************
 
+# The OpenStack Identity (Keystone) bind endpoint.
+default['openstack']['endpoints']['identity-bind']['host'] = '127.0.0.1'
+default['openstack']['endpoints']['identity-bind']['scheme'] = nil
+default['openstack']['endpoints']['identity-bind']['port'] = nil
+default['openstack']['endpoints']['identity-bind']['path'] = nil
+default['openstack']['endpoints']['identity-bind']['bind_interface'] = nil
+
 # The OpenStack Identity (Keystone) API endpoint. This is commonly called
 # the Keystone Service endpoint...
 default['openstack']['endpoints']['identity-api']['host'] = '127.0.0.1'


### PR DESCRIPTION
This change binds the keystone listen IP to 0.0.0.0.

 .../openstack-common/attributes/default.rb         |    7 +++++++
 1 file changed, 7 insertions(+)

Crowbar-Pull-ID: d29c7fd219fc788910559b18e4aab97175bfa350

Crowbar-Release: development
