### PR TITLE
Interm Berkshelf support [6/6]

### DIFF
--- a/chef/Berksfile
+++ b/chef/Berksfile
@@ -1,1 +1,1 @@
-cookbook 'openstack-common', github: 'stackforge/cookbook-openstack-common'
+cookbook 'openstack-common', path: 'cookbooks/openstack-common'

--- a/chef/roles/openstack-base.rb
+++ b/chef/roles/openstack-base.rb
@@ -1,0 +1,5 @@
+name "openstack-base"
+description "Deploy OpenStack Base role"
+run_list(
+  "role[os-base]"
+)

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -43,7 +43,7 @@ nav:
     openstack: '"/openstack_users_guide.pdf", { :link => { :target => "_blank" } }'
 
 roles:
-  - name: os-base
+  - name: openstack-base
     jig: chef-solo
     requires:
       - crowbar-installed-node

--- a/crowbar_engine/barclamp_openstack/app/models/barclamp_openstack/base.rb
+++ b/crowbar_engine/barclamp_openstack/app/models/barclamp_openstack/base.rb
@@ -1,0 +1,16 @@
+# Copyright 2014, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class BarclampOpenstack::Server < BarclampChef::Role
+end

--- a/crowbar_engine/barclamp_openstack/barclamp_openstack.gemspec
+++ b/crowbar_engine/barclamp_openstack/barclamp_openstack.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails"
+  s.add_dependency "berkshelf"
   # s.add_dependency "jquery-rails"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
These changes get things to the point where there is a centralized
berkshelf so that we only need to check in 1 copy of the upstream cookbooks

 chef/Berksfile                                     |    2 +-
 chef/roles/openstack-base.rb                       |    5 +++++
 crowbar.yml                                        |    2 +-
 .../app/models/barclamp_openstack/base.rb          |   16 ++++++++++++++++
 .../barclamp_openstack/barclamp_openstack.gemspec  |    1 +
 5 files changed, 24 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 651b5e8f8b7dd85967f4ecf104c8b44082568c45

Crowbar-Release: development
