### PR TITLE
Interm Berkshelf support [6/6]

### DIFF
--- a/chef/Berksfile
+++ b/chef/Berksfile
@@ -1,1 +1,1 @@
-cookbook 'openstack-common', github: 'stackforge/cookbook-openstack-common'
+cookbook 'openstack-common', path: 'cookbooks/openstack-common'

--- a/chef/roles/openstack-base.rb
+++ b/chef/roles/openstack-base.rb
@@ -1,0 +1,5 @@
+name "openstack-base"
+description "Deploy OpenStack Base role"
+run_list(
+  "role[os-base]"
+)

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -43,7 +43,7 @@ nav:
     openstack: '"/openstack_users_guide.pdf", { :link => { :target => "_blank" } }'
 
 roles:
-  - name: os-base
+  - name: openstack-base
     jig: chef-solo
     requires:
       - crowbar-installed-node

--- a/crowbar_engine/barclamp_openstack/app/models/barclamp_openstack/base.rb
+++ b/crowbar_engine/barclamp_openstack/app/models/barclamp_openstack/base.rb
@@ -1,0 +1,16 @@
+# Copyright 2014, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class BarclampOpenstack::Base < BarclampChef::Role
+end

--- a/crowbar_engine/barclamp_openstack/barclamp_openstack.gemspec
+++ b/crowbar_engine/barclamp_openstack/barclamp_openstack.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails"
+  s.add_dependency "berkshelf"
   # s.add_dependency "jquery-rails"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
This set of pull request is the first in a series that implements
interm Berkshelf support.

Design:

This assumes that there is a berkshelf checked in to the openstack
barclamp.  This change will come in a separate pull request so as
to not muddy the waters.

When the user clicks the table cell to target a role to a node,
on_proposed is called on the role.  This causes "berks package"
to be called, which creates a package.tar.gz file that contains
all of the dependent cookbooks.  Note that this only happens
once for each role.

The chef-solo jig then scp's the package.tar.gz to the target
node, and unzips it.

All of this only occurs if there is a file named
Berksfile.central in the same directory as the Berksfile for
the barclamp, so it will not effect current operation.

Pull requests to come:
- pull request that checks in the berkshelf to the openstack bc
- pull request that adds a nasty hack to make appropriate dirs
  writeable so that "berks package" can work
- pull request that removes all of the unneeded copies of the
  dependent cookbooks

These pull requests do not address how the berkshelf is initially
created.  Discretion is the better part of valor, and the crowbar
team will address this as part of on-line mode.

 chef/Berksfile                                     |    2 +-
 chef/roles/openstack-base.rb                       |    5 +++++
 crowbar.yml                                        |    2 +-
 .../app/models/barclamp_openstack/base.rb          |   16 ++++++++++++++++
 .../barclamp_openstack/barclamp_openstack.gemspec  |    1 +
 5 files changed, 24 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: c883448c62c77b5d87ff5d0e991668b6e825ec1d

Crowbar-Release: development
