### PR TITLE
Added flag to handle whether to update openstack components or not as suggested by upstream chef/openstack community. [1/1]

### DIFF
--- a/chef/cookbooks/openstack-common/attributes/default.rb
+++ b/chef/cookbooks/openstack-common/attributes/default.rb
@@ -71,6 +71,7 @@ default['openstack']['release'] = 'havana'
 # In the component strings, %codename% will be replaced by the value of
 # the node['lsb']['codename'] Ohai value and %release% will be replaced
 # by the value of node['openstack']['release']
+default['openstack']['apt']['live_updates_enabled'] = true
 default['openstack']['apt']['uri'] = 'http://ubuntu-cloud.archive.canonical.com/ubuntu'
 default['openstack']['apt']['components'] = ["precise-updates/#{node['openstack']['release']}", 'main']
 # For the SRU packaging, use this:

--- a/chef/cookbooks/openstack-common/recipes/default.rb
+++ b/chef/cookbooks/openstack-common/recipes/default.rb
@@ -23,19 +23,21 @@ when 'debian'
   package 'ubuntu-cloud-keyring' do
     action :install
   end
+  
+  if node['openstack']['apt']['live_updates_enabled']
+    apt_components = node['openstack']['apt']['components']
 
-  apt_components = node['openstack']['apt']['components']
+    # Simple variable substitution for LSB codename and OpenStack release
+    apt_components.each do | comp |
+      comp.gsub! '%release%', node['openstack']['release']
+      comp.gsub! '%codename%', node['lsb']['codename']
+    end
 
-  # Simple variable substitution for LSB codename and OpenStack release
-  apt_components.each do | comp |
-    comp.gsub! '%release%', node['openstack']['release']
-    comp.gsub! '%codename%', node['lsb']['codename']
-  end unless apt_components.nil? || apt_components.length == 0
-
-  apt_repository 'openstack-ppa' do
-    uri node['openstack']['apt']['uri']
-    components apt_components
-  end unless apt_components.nil? || apt_components.length == 0
+    apt_repository 'openstack-ppa' do
+      uri node['openstack']['apt']['uri']
+      components apt_components
+    end
+  end
 
 when 'rhel'
 

--- a/chef/cookbooks/openstack-custom/recipes/default.rb
+++ b/chef/cookbooks/openstack-custom/recipes/default.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 #
 
-node.override['openstack']['apt']['components'] = []
-Chef::Log.debug("Override set for ['openstack']['apt']['components']: #{node['openstack']['apt']['components']}")
+node.override['openstack']['apt']['live_updates_enabled'] = false
+Chef::Log.debug("Override set for ['openstack']['apt']['live_updates_enabled']: #{node['openstack']['apt']['live_updates_enabled']}")


### PR DESCRIPTION
 .../openstack-common/attributes/default.rb         |    1 +
 chef/cookbooks/openstack-common/recipes/default.rb |   24 +++++++++++---------
 chef/cookbooks/openstack-custom/recipes/default.rb |    4 ++--
 3 files changed, 16 insertions(+), 13 deletions(-)

Crowbar-Pull-ID: a5922ae1f014871c3b36dcbc506ae11210f85ec7

Crowbar-Release: development
