### PR TITLE
Set crowbar-openstack cookbook name in metadata

### DIFF
--- a/chef/cookbooks/crowbar-openstack/metadata.rb
+++ b/chef/cookbooks/crowbar-openstack/metadata.rb
@@ -1,3 +1,4 @@
+name             "crowbar-openstack"
 maintainer       "Crowbar Project"
 maintainer_email "crowbar@dell.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Needed if the cookbook is used without the crowbar framework. I.e. using
the cookbook as berkshelf dependency.